### PR TITLE
Add Terraform EC2 provisioning module and Grafana auto-configuration

### DIFF
--- a/control-node/docker-compose.yml
+++ b/control-node/docker-compose.yml
@@ -53,6 +53,8 @@ services:
       - grafana_data:/var/lib/grafana
     networks:
       - devnet
+    depends_on:
+      - prometheus
 
 networks:
   devnet:

--- a/control-node/grafana_config/datasources/datasource.yml
+++ b/control-node/grafana_config/datasources/datasource.yml
@@ -1,0 +1,7 @@
+apiVersion: 1
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true

--- a/control-node/terraform/aws_ec2_instance
+++ b/control-node/terraform/aws_ec2_instance
@@ -1,8 +1,8 @@
 resource "aws_instance" "copilot_instance" {
 ami = "ami-0c02fb55956c7d316" # Amazon Linux 2
-intance_type = var.instance_type
-tags{
-name= "infracopilot-dev"
+instance_type = var.instance_type
+tags={
+Name= "infracopilot-dev"
 
 }
 

--- a/control-node/terraform/aws_ec2_instance
+++ b/control-node/terraform/aws_ec2_instance
@@ -1,0 +1,13 @@
+resource "aws_instance" "copilot_instance" {
+ami = "ami-0c02fb55956c7d316" # Amazon Linux 2
+intance_type = var.instance_type
+tags{
+name= "infracopilot-dev"
+
+}
+
+
+
+
+
+}

--- a/control-node/terraform/outputs.tf
+++ b/control-node/terraform/outputs.tf
@@ -1,0 +1,4 @@
+output "instance_id" { 
+description = "This is the ID of the EC2 instance"
+value = aws_instance.copilot_instance.id 
+}

--- a/control-node/terraform/provider.tf
+++ b/control-node/terraform/provider.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+region = "ap-souht-1" #Mumbai
+}

--- a/control-node/terraform/readme.md
+++ b/control-node/terraform/readme.md
@@ -1,0 +1,23 @@
+# Terraform Module – EC2 Instance Provisioning
+
+This module provisions a basic Amazon EC2 instance to act as the control node for the InfraCopilot DevSecOps platform.
+
+## ✅ Features
+- Deploys an EC2 instance using Amazon Linux 2
+- Configurable instance type (`t2.micro` by default)
+- Tags the instance as `infracopilot-dev`
+
+## 📁 Files
+- `main.tf`: EC2 instance definition
+- `variables.tf`: Input variables
+- `provider.tf`: AWS provider setup
+- `outputs.tf`: Output instance ID
+
+## 🚀 Usage
+```bash
+terraform init
+terraform validate
+terraform plan
+terraform apply
+```
+- Requires aws credentials for "aws configure"

--- a/control-node/terraform/variables.tf
+++ b/control-node/terraform/variables.tf
@@ -1,0 +1,7 @@
+variable "instance_type" {
+description = "the type of ec2 instance to launch"
+type = string
+default = "t2.micro"
+
+  
+}


### PR DESCRIPTION
### Summary

This PR adds two key components to the InfraCopilot setup:

1. 🏗️ **Terraform Module** (under `control-node/terraform/`)
   - Provisions a basic EC2 instance using Amazon Linux 2
   - Modular, reusable, and configured with default region (ap-south-1)
   - Includes variable definition, provider config, and output block

2. 📊 **Grafana Provisioning Config** (under `grafana_config/datasources/`)
   - Automatically connects Grafana to Prometheus on startup
   - Uses `datasource.yml` for clean, repeatable observability setup

### Files Added
- Terraform: `main.tf`, `provider.tf`, `variables.tf`, `outputs.tf`, `README.md`
- Grafana: `datasource.yml` in the correct provisioning path

### Notes
- AWS credentials are required to apply Terraform.

